### PR TITLE
Feature/t 001 criar mapper dto

### DIFF
--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeController.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeController.java
@@ -21,26 +21,20 @@ public class ClubeController {
 
     // Criar jogador (CREATE)
     @PostMapping("/criarClube")
-    public ClubeModel criaClube (@RequestBody ClubeModel clube) {
+    public ClubeDTO criaClube (@RequestBody ClubeDTO clube) {
         return clubeService.criarClube(clube);
     }
 
     // Lista todos os jogadores (CREATE)
     @GetMapping("/listarClubes")
-    public List<ClubeModel> listarClubes () {
+    public List<ClubeDTO> listarClubes () {
         return clubeService.listarClubes();
     }
 
     // Lista todos os jogadores por id
     @GetMapping("/listarClubes/{id}")
-    public ClubeModel listaClubesPorId (@PathVariable Long id) {
+    public ClubeDTO listaClubesPorId (@PathVariable Long id) {
         return clubeService.listarClubesPorId(id);
-    }
-
-    // Altera jogador (UPDATE)
-    @PutMapping("/alterar")
-    public String alterarClube () {
-        return "Altera Clube";
     }
 
     // Deleta jogador (DELETE)
@@ -50,7 +44,7 @@ public class ClubeController {
     }
 
     @PutMapping("/alterClube/{id}")
-    public ClubeModel alterarClube (@PathVariable Long id, @RequestBody ClubeModel clubeAtualizado) {
+    public ClubeDTO alterarClube (@PathVariable Long id, @RequestBody ClubeDTO clubeAtualizado) {
         return clubeService.alterarClube(id, clubeAtualizado);
     }
 

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeDTO.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeDTO.java
@@ -1,0 +1,4 @@
+package br.com.rimeda.CadastroDeJogador.Clube;
+
+public class ClubeDTO {
+}

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeDTO.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeDTO.java
@@ -1,4 +1,17 @@
 package br.com.rimeda.CadastroDeJogador.Clube;
 
+import br.com.rimeda.CadastroDeJogador.Jogador.JogadorModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ClubeDTO {
+    private Long id;
+    private String nome;
+    private List<JogadorModel> jogadores;
 }

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeMapper.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeMapper.java
@@ -1,0 +1,4 @@
+package br.com.rimeda.CadastroDeJogador.Clube;
+
+public class ClubeMapper {
+}

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeMapper.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeMapper.java
@@ -1,4 +1,22 @@
 package br.com.rimeda.CadastroDeJogador.Clube;
 
 public class ClubeMapper {
+
+    public ClubeModel map (ClubeDTO clubeDTO){
+        ClubeModel clubeModel = new ClubeModel();
+        clubeModel.setId(clubeDTO.getId());
+        clubeModel.setNome(clubeDTO.getNome());
+        clubeModel.setJogadores(clubeDTO.getJogadores());
+
+        return clubeModel;
+    }
+
+    public ClubeDTO map (ClubeModel clubeModel) {
+        ClubeDTO clubeDTO = new ClubeDTO();
+        clubeDTO.setId(clubeModel.getId());
+        clubeDTO.setNome(clubeModel.getNome());
+        clubeDTO.setJogadores(clubeModel.getJogadores());
+        return clubeDTO;
+    }
+
 }

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeMapper.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeMapper.java
@@ -1,5 +1,8 @@
 package br.com.rimeda.CadastroDeJogador.Clube;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class ClubeMapper {
 
     public ClubeModel map (ClubeDTO clubeDTO){

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeService.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Clube/ClubeService.java
@@ -2,6 +2,7 @@ package br.com.rimeda.CadastroDeJogador.Clube;
 
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,32 +10,46 @@ import java.util.Optional;
 public class ClubeService {
 
     private ClubeRepository clubeRepository;
+    private ClubeMapper clubeMapper;
 
-    public ClubeService(ClubeRepository clubeRepository) {
+    public ClubeService(ClubeRepository clubeRepository, ClubeMapper clubeMapper) {
         this.clubeRepository = clubeRepository;
+        this.clubeMapper = clubeMapper;
     }
 
-    public List<ClubeModel> listarClubes(){
-        return clubeRepository.findAll();
+    public List<ClubeDTO> listarClubes(){
+        List<ClubeModel> clubeModels = clubeRepository.findAll();
+        List<ClubeDTO> clubeDTOS = new ArrayList<>();
+
+        for (ClubeModel c : clubeModels) {
+            clubeDTOS.add(clubeMapper.map(c));
+        }
+
+        return clubeDTOS;
     }
 
-    public ClubeModel listarClubesPorId (Long id){
-        Optional<ClubeModel> clubePorId = clubeRepository.findById(id);
-        return clubePorId.orElse(null);
+    public ClubeDTO listarClubesPorId (Long id){
+        ClubeModel clubePorId = clubeRepository.findById(id).orElse(null);
+        return (clubePorId == null) ? null : clubeMapper.map(clubePorId);
     }
 
-    public ClubeModel criarClube (ClubeModel clube){
-        return clubeRepository.save(clube);
+    public ClubeDTO criarClube (ClubeDTO clubeDTO){
+        ClubeModel clubeModel = clubeMapper.map(clubeDTO);
+        ClubeModel clubeSalvo = clubeRepository.save(clubeModel);
+        return clubeMapper.map(clubeSalvo);
     }
 
     public void deletarClube (Long id) {
         clubeRepository.deleteById(id);
     }
 
-    public ClubeModel alterarClube (Long id, ClubeModel clubeAtualizado) {
-        if (clubeRepository.existsById(id)) {
-            clubeAtualizado.setId(id);
-            return clubeRepository.save(clubeAtualizado);
+    public ClubeDTO alterarClube (Long id, ClubeDTO clubeAtualizado) {
+        Optional <ClubeModel> clubeExistente = clubeRepository.findById(id);
+        if (clubeExistente.isPresent()) {
+            ClubeModel clubeModel = clubeMapper.map(clubeAtualizado);
+            clubeModel.setId(id);
+            ClubeModel clubeSalvo = clubeRepository.save(clubeModel);
+            return clubeMapper.map(clubeSalvo);
         }
         return null;
     }

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorController.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorController.java
@@ -28,19 +28,19 @@ public class JogadorController {
 
     // Lista todos os jogadores (CREATE)
     @GetMapping("/listarJogadores")
-    public List<JogadorModel> listarJogadores () {
+    public List<JogadorDTO> listarJogadores () {
         return jogadorService.listarJogadores();
     }
 
     // Lista todos os jogadores por id
     @GetMapping("/listarJogadores/{id}")
-    public JogadorModel listaJogadoresId (@PathVariable Long id) {
+    public JogadorDTO listaJogadoresId (@PathVariable Long id) {
         return jogadorService.listarJogadoresPorId(id);
     }
 
     // Altera jogador (UPDATE)
     @PutMapping("/alterarJogador/{id}")
-    public JogadorModel alterarJogador (@PathVariable Long id, @RequestBody JogadorModel jogadorAtualizado) {
+    public JogadorDTO alterarJogador (@PathVariable Long id, @RequestBody JogadorDTO jogadorAtualizado) {
         return jogadorService.alterarJogador(id, jogadorAtualizado);
     }
 

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorController.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorController.java
@@ -22,7 +22,7 @@ public class JogadorController {
 
     // Criar jogador (CREATE)
     @PostMapping("/criarJogador")
-    public JogadorModel criaJogador (@RequestBody JogadorModel jogador) {
+    public JogadorDTO criaJogador (@RequestBody JogadorDTO jogador) {
         return jogadorService.criaJogador(jogador);
     }
 

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorDTO.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorDTO.java
@@ -1,4 +1,18 @@
 package br.com.rimeda.CadastroDeJogador.Jogador;
 
+import br.com.rimeda.CadastroDeJogador.Clube.ClubeModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class JogadorDTO {
+    private Long id;
+    private String nome;
+    private String instagram;
+    private int idade;
+    private ClubeModel clube;
+    private String corDePele;
 }

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorDTO.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorDTO.java
@@ -1,0 +1,4 @@
+package br.com.rimeda.CadastroDeJogador.Jogador;
+
+public class JogadorDTO {
+}

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorMapper.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorMapper.java
@@ -1,4 +1,34 @@
 package br.com.rimeda.CadastroDeJogador.Jogador;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class JogadorMapper {
+
+    public JogadorModel map (JogadorDTO jogadorDTO) {
+
+        JogadorModel jogadorModel = new JogadorModel();
+        jogadorModel.setId(jogadorDTO.getId());
+        jogadorModel.setNome(jogadorDTO.getNome());
+        jogadorModel.setIdade(jogadorDTO.getIdade());
+        jogadorModel.setInstagram(jogadorDTO.getInstagram());
+        jogadorModel.setClube(jogadorDTO.getClube());
+        jogadorModel.setCorDePele(jogadorDTO.getCorDePele());
+
+        return jogadorModel;
+    }
+
+    public JogadorDTO map (JogadorModel jogadorModel){
+
+        JogadorDTO jogadorDTO = new JogadorDTO();
+        jogadorDTO.setId(jogadorModel.getId());
+        jogadorDTO.setNome(jogadorModel.getNome());
+        jogadorDTO.setIdade(jogadorModel.getIdade());
+        jogadorDTO.setInstagram(jogadorModel.getInstagram());
+        jogadorDTO.setClube(jogadorModel.getClube());
+        jogadorDTO.setCorDePele(jogadorModel.getCorDePele());
+        return jogadorDTO;
+    }
+
+
 }

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorMapper.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorMapper.java
@@ -1,0 +1,4 @@
+package br.com.rimeda.CadastroDeJogador.Jogador;
+
+public class JogadorMapper {
+}

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorModel.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorModel.java
@@ -26,6 +26,9 @@ public class JogadorModel {
     @Column (name = "idade")
     private int idade;
 
+    @Column (name = "cor_de_pele")
+    private String corDePele;
+
     // @ManyToOne -> Muitos jogadores para um clube.
     @ManyToOne
     // @JoinColumn -> junta as tabelas através do primary key e nomeia de acordo com name.

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorService.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorService.java
@@ -8,9 +8,11 @@ import java.util.Optional;
 @Service
 public class JogadorService {
 
+    private JogadorMapper jogadorMapper;
     private JogadorRepository jogadorRepository;
 
-    public JogadorService(JogadorRepository jogadorRepository) {
+    public JogadorService(JogadorMapper jogadorMapper, JogadorRepository jogadorRepository) {
+        this.jogadorMapper = jogadorMapper;
         this.jogadorRepository = jogadorRepository;
     }
 
@@ -23,8 +25,10 @@ public class JogadorService {
         return jogadorPorId.orElse(null);
     }
 
-    public JogadorModel criaJogador (JogadorModel jogador) {
-        return jogadorRepository.save(jogador);
+    public JogadorDTO criaJogador (JogadorDTO jogadorDTO) {
+        JogadorModel jogador = jogadorMapper.map(jogadorDTO);
+        jogador = jogadorRepository.save(jogador);
+        return jogadorMapper.map(jogador);
     }
 
     public void deletarJogador (Long id) {

--- a/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorService.java
+++ b/src/main/java/br/com/rimeda/CadastroDeJogador/Jogador/JogadorService.java
@@ -2,6 +2,7 @@ package br.com.rimeda.CadastroDeJogador.Jogador;
 
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,18 +17,26 @@ public class JogadorService {
         this.jogadorRepository = jogadorRepository;
     }
 
-    public List<JogadorModel> listarJogadores() {
-        return jogadorRepository.findAll();
+    public List<JogadorDTO> listarJogadores() {
+        List <JogadorModel> jogadoresModel = jogadorRepository.findAll();
+        List<JogadorDTO> jogadorDTOS = new ArrayList<>();
+
+            for (JogadorModel j : jogadoresModel) {
+                jogadorDTOS.add(jogadorMapper.map(j));
+            }
+
+            return jogadorDTOS;
+
     }
 
-    public JogadorModel listarJogadoresPorId(Long id){
-        Optional<JogadorModel> jogadorPorId = jogadorRepository.findById(id);
-        return jogadorPorId.orElse(null);
+    public JogadorDTO listarJogadoresPorId(Long id){
+       JogadorModel jogadorModel = jogadorRepository.findById(id).orElse(null);
+        return jogadorModel == null ? null : jogadorMapper.map(jogadorModel);
     }
 
     public JogadorDTO criaJogador (JogadorDTO jogadorDTO) {
         JogadorModel jogador = jogadorMapper.map(jogadorDTO);
-        jogador = jogadorRepository.save(jogador);
+        JogadorModel jogadorSalvo = jogadorRepository.save(jogador);
         return jogadorMapper.map(jogador);
     }
 
@@ -35,10 +44,13 @@ public class JogadorService {
         jogadorRepository.deleteById(id);
     }
 
-    public JogadorModel alterarJogador (Long id, JogadorModel jogadorAtualizado) {
-        if (jogadorRepository.existsById(id)) {
-            jogadorAtualizado.setId(id);
-            return jogadorRepository.save(jogadorAtualizado);
+    public JogadorDTO alterarJogador (Long id, JogadorDTO jogadorAtualizado) {
+        Optional<JogadorModel> jogadorExistente = jogadorRepository.findById(id);
+        if (jogadorExistente.isPresent()) {
+            JogadorModel jogadorModel = jogadorMapper.map(jogadorAtualizado);
+            jogadorModel.setId(id);
+            JogadorModel jogadorSalvo = jogadorRepository.save(jogadorModel);
+            return jogadorAtualizado = jogadorMapper.map(jogadorSalvo);
         }
         return null;
     }


### PR DESCRIPTION
Este PR introduz uma camada adicional de DTOs e Mappers para as entidades Jogador e Clube, com o objetivo de desacoplar a API dos Models de domínio e centralizar a transformação de dados em um ponto único e consistente.

Principais mudanças:
Criação de DTOs e Mappers para Jogador e Clube, padronizando as conversões entre entidades e objetos expostos/consumidos pela API.
Refatoração dos Controllers para trabalhar com DTOs, removendo a responsabilidade de montagem/normalização de payload diretamente a partir dos Models.
Refatoração dos Services para mover regras de conversão/retorno para DTOs/Mappers, reduzindo acoplamento e responsabilidades indevidas nas entidades.

Motivação / Benefícios:
Separação de responsabilidades (SRP): Models focados em domínio/persistência; DTOs focados em contrato de API.
Menor acoplamento e maior manutenibilidade: mudanças no domínio impactam menos a camada de apresentação.
Melhor consistência e testabilidade: regras de mapeamento ficam centralizadas e mais fáceis de validar.

Impacto:
Alteração estrutural em Controller/Service de Jogador e Clube para uso de DTOs.
Sem mudança de regra de negócio esperada; foco em organização, clareza e arquitetura.